### PR TITLE
[VBLOCKS-6744] reliability & security

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,15 @@ npm install
 cp example.env .env
 ```
 
-4. In the Twilio Console, open your **TwiML App** settings and set **Voice Request URL** to the endpoint for the component you want to test:
+4. Expose your local server to the public internet so Twilio can reach it for webhooks. If you run the components locally, use a tunneling service such as [ngrok](https://ngrok.com/).
+
+```bash
+ngrok http 3030
+```
+
+Copy the forwarding host that ngrok prints (e.g. `abc123.ngrok-free.app`) and set it as `CALLBACK_BASE_URL` in your `.env` — **without** the `https://` scheme, since the code prepends `https://` / `wss://` itself. If you changed `PORT`, tunnel to that port instead of `3030`.
+
+5. In the Twilio Console, open your **TwiML App** settings and set **Voice Request URL** to the endpoint for the component you want to test, using your public host from step 4 in place of `yourdomain`:
 
 ```text
 https://yourdomain/twilio-voice-dialer/twiml

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.0",
       "dependencies": {
         "@twilio/voice-sdk": "2.15.0",
-        "dotenv": "17.2.0",
-        "express": "4.21.0",
+        "dotenv": "17.4.2",
+        "express": "4.22.2",
         "openai": "5.10.1",
         "twilio": "5.7.3",
-        "ws": "8.18.3"
+        "ws": "8.21.0"
       },
       "engines": {
         "node": ">=22"
@@ -102,43 +102,73 @@
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.17.0",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
-      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "version": "1.20.5",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
+        "bytes": "~3.1.2",
         "content-type": "~1.0.5",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "destroy": "1.2.0",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "on-finished": "2.4.1",
-        "qs": "6.13.0",
-        "raw-body": "2.5.2",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
-        "unpipe": "1.0.0"
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -149,7 +179,7 @@
     },
     "node_modules/bytes": {
       "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/bytes/-/bytes-3.1.2.tgz",
       "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
       "license": "MIT",
       "engines": {
@@ -187,7 +217,7 @@
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
       "dependencies": {
@@ -211,7 +241,7 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/content-type/-/content-type-1.0.5.tgz",
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "license": "MIT",
       "engines": {
@@ -219,9 +249,9 @@
       }
     },
     "node_modules/cookie": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "version": "0.7.2",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -250,7 +280,7 @@
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
       "engines": {
@@ -277,9 +307,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "17.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
-      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
+      "version": "17.4.2",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -358,7 +388,7 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "license": "MIT",
       "dependencies": {
@@ -396,45 +426,49 @@
       }
     },
     "node_modules/express": {
-      "version": "4.21.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
-      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
+      "version": "4.22.2",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.3",
-        "content-disposition": "0.5.4",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
-        "cookie": "0.6.0",
-        "cookie-signature": "1.0.6",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
         "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.3.1",
-        "fresh": "0.5.2",
-        "http-errors": "2.0.0",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
         "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
-        "on-finished": "2.4.1",
+        "on-finished": "~2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.10",
+        "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "6.13.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.19.0",
-        "serve-static": "1.16.2",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
         "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
+        "statuses": "~2.0.1",
         "type-is": "~1.6.18",
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       },
       "engines": {
         "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/finalhandler": {
@@ -456,9 +490,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -476,9 +510,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -581,7 +615,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "license": "MIT",
       "dependencies": {
@@ -660,7 +694,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "license": "MIT",
       "dependencies": {
@@ -725,12 +759,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -800,7 +834,7 @@
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "license": "MIT",
       "engines": {
@@ -928,9 +962,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
-      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
+      "version": "0.1.13",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/proxy-addr": {
@@ -947,18 +981,21 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/qs": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
-      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "version": "6.15.2",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.6"
+        "side-channel": "^1.1.0"
       },
       "engines": {
         "node": ">=0.6"
@@ -977,16 +1014,45 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "version": "2.5.3",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body/node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
@@ -1013,7 +1079,7 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
@@ -1205,7 +1271,7 @@
     },
     "node_modules/type-is": {
       "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/type-is/-/type-is-1.6.18.tgz",
       "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "license": "MIT",
       "dependencies": {
@@ -1244,10 +1310,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "twilio-voice-js-reference-components",
       "version": "1.0.0",
       "dependencies": {
-        "@twilio/voice-sdk": "2.15.0",
+        "@twilio/voice-sdk": "2.18.3",
         "dotenv": "17.4.2",
         "express": "4.22.2",
         "openai": "5.10.1",
@@ -21,20 +21,21 @@
     },
     "node_modules/@twilio/voice-errors": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@twilio/voice-errors/-/voice-errors-1.7.0.tgz",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/@twilio/voice-errors/-/voice-errors-1.7.0.tgz",
       "integrity": "sha512-9TvniWpzU0iy6SYFAcDP+HG+/mNz2yAHSs7+m0DZk86lE+LoTB6J/ZONTPuxXrXWi4tso/DulSHuA0w7nIQtGg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/@twilio/voice-sdk": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/@twilio/voice-sdk/-/voice-sdk-2.15.0.tgz",
-      "integrity": "sha512-4FhRrUVJrek/U85F29G3+r5hbh7Lg2aapUE8jh/DnG0SiIktbW+MvFw2PxOwW0xVCbPigT7NHNo8/uzc3EmXkg==",
+      "version": "2.18.3",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/@twilio/voice-sdk/-/voice-sdk-2.18.3.tgz",
+      "integrity": "sha512-sBa9Tw+aXVIqDVnFQXIoY+yZM8GI8v/fwt34EMElSUfvlb8kquDOwLv6wXrBOwSYrnlyJoUqjlAOWdFPizEBnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@twilio/voice-errors": "1.7.0",
-        "@types/events": "^3.0.3",
+        "@types/events": "3.0.3",
         "events": "3.3.0",
-        "loglevel": "1.6.7"
+        "loglevel": "1.9.2",
+        "tslib": "2.8.1"
       },
       "engines": {
         "node": ">= 12"
@@ -42,7 +43,7 @@
     },
     "node_modules/@types/events": {
       "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/@types/events/-/events-3.0.3.tgz",
       "integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==",
       "license": "MIT"
     },
@@ -418,7 +419,7 @@
     },
     "node_modules/events": {
       "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
       "engines": {
@@ -811,16 +812,16 @@
       "license": "MIT"
     },
     "node_modules/loglevel": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
-      "integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A==",
+      "version": "1.9.2",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6.0"
       },
       "funding": {
         "type": "tidelift",
-        "url": "https://tidelift.com/subscription/pkg/npm-loglevel?utm_medium=referral&utm_source=npm_fund"
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
       }
     },
     "node_modules/math-intrinsics": {
@@ -1250,6 +1251,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://npmjs.artifacts.twilio.com/artifactory/api/npm/virtual-npm-thirdparty/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/twilio": {
       "version": "5.7.3",

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
   },
   "dependencies": {
     "@twilio/voice-sdk": "2.15.0",
-    "dotenv": "17.2.0",
-    "express": "4.21.0",
+    "dotenv": "17.4.2",
+    "express": "4.22.2",
     "openai": "5.10.1",
     "twilio": "5.7.3",
-    "ws": "8.18.3"
+    "ws": "8.21.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "node": ">=22"
   },
   "dependencies": {
-    "@twilio/voice-sdk": "2.15.0",
+    "@twilio/voice-sdk": "2.18.3",
     "dotenv": "17.4.2",
     "express": "4.22.2",
     "openai": "5.10.1",

--- a/src/common/routes.js
+++ b/src/common/routes.js
@@ -98,7 +98,12 @@ export const twimlHandler = async (req, res, componentUrl, options = {}) => {
       to: recipient,
     });
   } catch (error) {
-    console.error(`Failed to add callee to conference ${roomName}:`, error);
+    // The TwiML response was already sent, so the caller is in an empty
+    // conference and the failure can only be surfaced via these logs.
+    console.error(`Failed to add callee to conference ${roomName}:`, error.message, {
+      status: error.status,
+      code: error.code,
+    });
   }
 };
 
@@ -200,7 +205,13 @@ export const conferenceEventsHandler = async (req, res, componentUrl, options = 
           console.error('Failed to send conference-status message:', result.reason)
         );
     } catch (error) {
-      console.error(`Failed to handle conference event for ${ConferenceSid}:`, error);
+      // Log only the error summary, not the full Twilio error object, which can
+      // carry account SIDs, API response bodies, or PII into log aggregators.
+      console.error(
+        `Failed to handle conference event for ${ConferenceSid}:`,
+        error.message,
+        { status: error.status, code: error.code }
+      );
     }
   }
 

--- a/src/common/routes.js
+++ b/src/common/routes.js
@@ -39,7 +39,7 @@ export const tokenHandler = (req, res) => {
 /**
  * Handler for the TwiML App Webhook, set in the User's Twilio Console.
  */
-export const twimlHandler = (req, res, componentUrl, options = {}) => {
+export const twimlHandler = async (req, res, componentUrl, options = {}) => {
   const {
     calleeStatusCallbackEvent = [],
     calleeLabel = 'callee',
@@ -74,24 +74,32 @@ export const twimlHandler = (req, res, componentUrl, options = {}) => {
     roomName
   );
 
-  // Add the callee to the conference
-  client.conferences(roomName).participants.create({
-    beep: 'false',
-    endConferenceOnExit: true,
-    from: callerId,
-    // Label to identify this participant
-    label: `${isPhoneNumber(recipient) ? 'number' : 'client'}-${calleeLabel}`,
-    // Callee's progress/status
-    // https://www.twilio.com/docs/voice/api/conference-participant-resource#request-body-parameters
-    statusCallback:
-      calleeStatusCallbackEvent.length > 0
-        ? `https://${callbackBaseUrl}/${componentUrl}/call-events`
-        : '',
-    statusCallbackEvent: calleeStatusCallbackEvent,
-    to: recipient,
-  });
-
+  // Respond with the TwiML first so the caller joins and creates the conference
+  // with the statusCallback configured above. If the callee were added first,
+  // the REST API would create the conference without a status callback and no
+  // conference events would ever be delivered.
   res.header('Content-Type', 'text/xml').status(200).send(twiml.toString());
+
+  // Add the callee to the conference
+  try {
+    await client.conferences(roomName).participants.create({
+      beep: 'false',
+      endConferenceOnExit: true,
+      from: callerId,
+      // Label to identify this participant
+      label: `${isPhoneNumber(recipient) ? 'number' : 'client'}-${calleeLabel}`,
+      // Callee's progress/status
+      // https://www.twilio.com/docs/voice/api/conference-participant-resource#request-body-parameters
+      statusCallback:
+        calleeStatusCallbackEvent.length > 0
+          ? `https://${callbackBaseUrl}/${componentUrl}/call-events`
+          : '',
+      statusCallbackEvent: calleeStatusCallbackEvent,
+      to: recipient,
+    });
+  } catch (error) {
+    console.error(`Failed to add callee to conference ${roomName}:`, error);
+  }
 };
 
 /**
@@ -126,56 +134,74 @@ export const conferenceEventsHandler = async (req, res, componentUrl, options = 
   }
 
   if (shouldSendMessage) {
-    const participants = await client
-      .conferences(ConferenceSid)
-      .participants.list();
+    try {
+      const participants = await client
+        .conferences(ConferenceSid)
+        .participants.list();
 
-    // Send the conference sid and the other participants' callSids to any client leg.
-    // The sids will be used to update the participant resource such as putting it on hold.
-    participants.forEach(async (currentParticipant) => {
-      if (currentParticipant.label.split('-')[0] === 'client') {
+      // Send the conference sid and the other participants' callSids to any client leg.
+      // The sids will be used to update the participant resource such as putting it on hold.
+      const clientParticipants = participants.filter(
+        (participant) => participant.label?.split('-')[0] === 'client'
+      );
+
+      // Collect every message to send so we can await them and surface failures
+      // instead of firing async callbacks inside forEach (unhandled rejections).
+      const messages = [];
+      clientParticipants.forEach((currentParticipant) => {
         // When the StatusCallbackEvent is 'participant-leave', the req.body contains data
         // from the participant that left the conference. Send the callSid and data of the
         // participant that left the conference to all current client legs.
         if (StatusCallbackEvent === 'participant-leave') {
-          await client
-            .calls(currentParticipant.callSid)
-            .userDefinedMessages
-            .create({
-              content: JSON.stringify({
-                callSid: CallSid,
-                category: 'conference-status',
-                conferenceSid: ConferenceSid,
-                hold: Hold,
-                label: ParticipantLabel,
-                muted: Muted,
-                remove: true,
-                statusCallbackEvent: StatusCallbackEvent,
-              }),
-            });
+          messages.push({
+            callSid: currentParticipant.callSid,
+            content: {
+              callSid: CallSid,
+              category: 'conference-status',
+              conferenceSid: ConferenceSid,
+              hold: Hold,
+              label: ParticipantLabel,
+              muted: Muted,
+              remove: true,
+              statusCallbackEvent: StatusCallbackEvent,
+            },
+          });
         } else {
           participants
-            .filter((p) => p.callSid !== currentParticipant.callSid)
-            .forEach(async (otherParticipant) => {
-              await client
-                .calls(currentParticipant.callSid)
-                .userDefinedMessages
-                .create({
-                  content: JSON.stringify({
-                    callSid: otherParticipant.callSid,
-                    category: 'conference-status',
-                    conferenceSid: ConferenceSid,
-                    hold: otherParticipant.hold,
-                    label: otherParticipant.label,
-                    muted: otherParticipant.muted,
-                    remove: false,
-                    statusCallbackEvent: StatusCallbackEvent,
-                  }),
-                });
+            .filter((participant) => participant.callSid !== currentParticipant.callSid)
+            .forEach((otherParticipant) => {
+              messages.push({
+                callSid: currentParticipant.callSid,
+                content: {
+                  callSid: otherParticipant.callSid,
+                  category: 'conference-status',
+                  conferenceSid: ConferenceSid,
+                  hold: otherParticipant.hold,
+                  label: otherParticipant.label,
+                  muted: otherParticipant.muted,
+                  remove: false,
+                  statusCallbackEvent: StatusCallbackEvent,
+                },
+              });
             });
         }
-      }
-    });
+      });
+
+      const results = await Promise.allSettled(
+        messages.map(({ callSid, content }) =>
+          client.calls(callSid).userDefinedMessages.create({
+            content: JSON.stringify(content),
+          })
+        )
+      );
+      results
+        .filter((result) => result.status === 'rejected')
+        .forEach((result) =>
+          console.error('Failed to send conference-status message:', result.reason)
+        );
+    } catch (error) {
+      console.error(`Failed to handle conference event for ${ConferenceSid}:`, error);
+    }
   }
 
   res.sendStatus(200);

--- a/src/components/twilio-voice-basic-call-control/public/twilio-voice-basic-call-control.js
+++ b/src/components/twilio-voice-basic-call-control/public/twilio-voice-basic-call-control.js
@@ -49,7 +49,7 @@ class TwilioVoiceBasicCallControl extends HTMLElement {
   async #handleAddConference() {
     const response = await this.#addConference();
     if (response.status !== 200) {
-      console.error('Unable to add participant to call: ', response.error);
+      console.error('Unable to add participant to call: ', (await response.json()).error);
     }
   }
 
@@ -72,7 +72,7 @@ class TwilioVoiceBasicCallControl extends HTMLElement {
   async #handleForwardCall() {
     const response = await this.#addConference();
     if (response.status !== 200) {
-      console.error('Unable to forward call: ', response.error);
+      console.error('Unable to forward call: ', (await response.json()).error);
       return;
     }
 
@@ -85,7 +85,7 @@ class TwilioVoiceBasicCallControl extends HTMLElement {
     });
 
     if (response.status !== 200) {
-      console.error('Unable to set hold: ', response.error);
+      console.error('Unable to set hold: ', (await response.json()).error);
       return;
     }
     this.#showElement(`#${callSid}-hold`, !shouldHold);
@@ -98,7 +98,7 @@ class TwilioVoiceBasicCallControl extends HTMLElement {
     });
 
     if (response.status !== 200) {
-      console.error('Unable to set mute: ', response.error);
+      console.error('Unable to set mute: ', (await response.json()).error);
       return;
     }
     this.#showElement(`#${callSid}-mute`, !shouldMute);
@@ -116,7 +116,7 @@ class TwilioVoiceBasicCallControl extends HTMLElement {
     );
 
     if (response.status !== 200) {
-      console.error('Unable to remove participant: ', response.error);
+      console.error('Unable to remove participant: ', (await response.json()).error);
     }
   }
 

--- a/src/components/twilio-voice-basic-call-control/routes.js
+++ b/src/components/twilio-voice-basic-call-control/routes.js
@@ -18,12 +18,9 @@ router.get('/token', (req, res) => tokenHandler(req, res));
 
 // Validate incoming Twilio requests
 // https://www.twilio.com/docs/usage/tutorials/how-to-secure-your-express-app-by-validating-incoming-twilio-requests
-router.post('/twiml', Twilio.webhook({ protocol: 'https' }, authToken), (req, res) =>
-  twimlHandler(
-    req,
-    res,
-    componentUrl,
-    {
+router.post('/twiml', Twilio.webhook({ protocol: 'https' }, authToken), async (req, res) => {
+  try {
+    await twimlHandler(req, res, componentUrl, {
       callerLabel: 'agent1',
       calleeLabel: 'customer',
       // 3 participants needed for warm transfer: agent1, agent2, and customer.
@@ -31,9 +28,15 @@ router.post('/twiml', Twilio.webhook({ protocol: 'https' }, authToken), (req, re
       // Allow agent1 to drop from call, while agent2 and customer continue call.
       endConferenceOnExit: false,
       statusCallbackEvent: 'join leave mute hold',
-    }
-  )
-);
+    });
+  } catch (error) {
+    console.error('Failed to handle twiml:', error.message, {
+      status: error.status,
+      code: error.code,
+    });
+    if (!res.headersSent) res.sendStatus(500);
+  }
+});
 
 // Validate incoming Twilio requests
 // https://www.twilio.com/docs/usage/tutorials/how-to-secure-your-express-app-by-validating-incoming-twilio-requests
@@ -78,13 +81,20 @@ router.post('/conferences/:conferenceSid/participants', async (req, res) => {
 router.post('/conferences/:conferenceSid/participants/:callSid', async (req, res) => {
   const { callSid, conferenceSid } = req.params;
 
+  // Whitelist only the fields the UI controls. Passing req.body straight to
+  // update() would forward arbitrary Participant resource fields (e.g.
+  // coaching, callSidToCoach), letting anyone with a valid token set sensitive
+  // params. https://www.twilio.com/docs/voice/api/conference-participant-resource#update-a-participant-resource
+  const update = {};
+  if ('hold' in req.body) update.hold = req.body.hold;
+  if ('muted' in req.body) update.muted = req.body.muted;
+
   try {
     // Update a Participant resource
-    // https://www.twilio.com/docs/voice/api/conference-participant-resource#update-a-participant-resource
     await client
       .conferences(conferenceSid)
       .participants(callSid)
-      .update(req.body);
+      .update(update);
     res.sendStatus(200);
   } catch (error) {
     console.error(`Failed to update participant ${callSid} in conference ${conferenceSid}:`, error);

--- a/src/components/twilio-voice-basic-call-control/routes.js
+++ b/src/components/twilio-voice-basic-call-control/routes.js
@@ -71,7 +71,7 @@ router.post('/conferences/:conferenceSid/participants', async (req, res) => {
     res.sendStatus(200);
   } catch (error) {
     console.error(`Failed to add participant to conference ${conferenceSid}:`, error);
-    res.status(500).send({ error: error.message });
+    res.status(500).send({ error: 'Failed to add participant to conference' });
   }
 });
 
@@ -88,7 +88,7 @@ router.post('/conferences/:conferenceSid/participants/:callSid', async (req, res
     res.sendStatus(200);
   } catch (error) {
     console.error(`Failed to update participant ${callSid} in conference ${conferenceSid}:`, error);
-    res.status(500).send({ error: error.message });
+    res.status(500).send({ error: 'Failed to update conference participant' });
   }
 });
 
@@ -105,7 +105,7 @@ router.delete('/conferences/:conferenceSid/participants/:callSid', async (req, r
     res.sendStatus(200);
   } catch (error) {
     console.error(`Failed to remove participant ${callSid} from conference ${conferenceSid}:`, error);
-    res.status(500).send({ error: error.message });
+    res.status(500).send({ error: 'Failed to remove conference participant' });
   }
 });
 

--- a/src/components/twilio-voice-basic-call-control/routes.js
+++ b/src/components/twilio-voice-basic-call-control/routes.js
@@ -30,7 +30,7 @@ router.post('/twiml', Twilio.webhook({ protocol: 'https' }, authToken), (req, re
       maxParticipants: 3,
       // Allow agent1 to drop from call, while agent2 and customer continue call.
       endConferenceOnExit: false,
-      statusCallbackEvent: 'join, leave, mute, hold',
+      statusCallbackEvent: 'join leave mute hold',
     }
   )
 );
@@ -60,41 +60,53 @@ router.post('/conferences/:conferenceSid/participants', async (req, res) => {
   let to = req.body.to;
   to = isPhoneNumber(to) ? to : 'client:' + to;
 
-  // Add agent2 to the conference
-  await client.conferences(conferenceSid).participants.create({
-    label: `${isPhoneNumber(to) ? 'number' : 'client'}-agent2`,
-    from: callerId,
-    to,
-    endConferenceOnExit: true,
-  });
-
-  res.sendStatus(200);
+  try {
+    // Add agent2 to the conference
+    await client.conferences(conferenceSid).participants.create({
+      label: `${isPhoneNumber(to) ? 'number' : 'client'}-agent2`,
+      from: callerId,
+      to,
+      endConferenceOnExit: true,
+    });
+    res.sendStatus(200);
+  } catch (error) {
+    console.error(`Failed to add participant to conference ${conferenceSid}:`, error);
+    res.status(500).send({ error: error.message });
+  }
 });
 
 router.post('/conferences/:conferenceSid/participants/:callSid', async (req, res) => {
   const { callSid, conferenceSid } = req.params;
 
-  // Update a Participant resource
-  // https://www.twilio.com/docs/voice/api/conference-participant-resource#update-a-participant-resource
-  await client
-    .conferences(conferenceSid)
-    .participants(callSid)
-    .update(req.body);
-
-  res.sendStatus(200);
+  try {
+    // Update a Participant resource
+    // https://www.twilio.com/docs/voice/api/conference-participant-resource#update-a-participant-resource
+    await client
+      .conferences(conferenceSid)
+      .participants(callSid)
+      .update(req.body);
+    res.sendStatus(200);
+  } catch (error) {
+    console.error(`Failed to update participant ${callSid} in conference ${conferenceSid}:`, error);
+    res.status(500).send({ error: error.message });
+  }
 });
 
 router.delete('/conferences/:conferenceSid/participants/:callSid', async (req, res) => {
   const { callSid, conferenceSid } = req.params;
 
-  // Delete a Participant resource
-  // https://www.twilio.com/docs/voice/api/conference-participant-resource#delete-a-participant-resource
-  await client
-    .conferences(conferenceSid)
-    .participants(callSid)
-    .remove();
-
-  res.sendStatus(200);
+  try {
+    // Delete a Participant resource
+    // https://www.twilio.com/docs/voice/api/conference-participant-resource#delete-a-participant-resource
+    await client
+      .conferences(conferenceSid)
+      .participants(callSid)
+      .remove();
+    res.sendStatus(200);
+  } catch (error) {
+    console.error(`Failed to remove participant ${callSid} from conference ${conferenceSid}:`, error);
+    res.status(500).send({ error: error.message });
+  }
 });
 
 export default router;

--- a/src/components/twilio-voice-basic-call-control/routes.js
+++ b/src/components/twilio-voice-basic-call-control/routes.js
@@ -40,12 +40,9 @@ router.post('/twiml', Twilio.webhook({ protocol: 'https' }, authToken), async (r
 
 // Validate incoming Twilio requests
 // https://www.twilio.com/docs/usage/tutorials/how-to-secure-your-express-app-by-validating-incoming-twilio-requests
-router.post('/conference-events', Twilio.webhook({ protocol: 'https' }, authToken), (req, res) =>
-  conferenceEventsHandler(
-    req,
-    res,
-    componentUrl,
-    {
+router.post('/conference-events', Twilio.webhook({ protocol: 'https' }, authToken), async (req, res) => {
+  try {
+    await conferenceEventsHandler(req, res, componentUrl, {
       statusCallbackEvents: [
         'participant-join',
         'participant-mute',
@@ -54,9 +51,15 @@ router.post('/conference-events', Twilio.webhook({ protocol: 'https' }, authToke
         'participant-unhold',
         'participant-leave',
       ],
-    }
-  )
-);
+    });
+  } catch (error) {
+    console.error('Failed to handle conference-events:', error.message, {
+      status: error.status,
+      code: error.code,
+    });
+    if (!res.headersSent) res.sendStatus(200);
+  }
+});
 
 router.post('/conferences/:conferenceSid/participants', async (req, res) => {
   const { conferenceSid } = req.params;
@@ -73,7 +76,7 @@ router.post('/conferences/:conferenceSid/participants', async (req, res) => {
     });
     res.sendStatus(200);
   } catch (error) {
-    console.error(`Failed to add participant to conference ${conferenceSid}:`, error);
+    console.error(`Failed to add participant to conference ${conferenceSid}:`, error.message, { status: error.status, code: error.code });
     res.status(500).send({ error: 'Failed to add participant to conference' });
   }
 });
@@ -97,7 +100,7 @@ router.post('/conferences/:conferenceSid/participants/:callSid', async (req, res
       .update(update);
     res.sendStatus(200);
   } catch (error) {
-    console.error(`Failed to update participant ${callSid} in conference ${conferenceSid}:`, error);
+    console.error(`Failed to update participant ${callSid} in conference ${conferenceSid}:`, error.message, { status: error.status, code: error.code });
     res.status(500).send({ error: 'Failed to update conference participant' });
   }
 });
@@ -114,7 +117,7 @@ router.delete('/conferences/:conferenceSid/participants/:callSid', async (req, r
       .remove();
     res.sendStatus(200);
   } catch (error) {
-    console.error(`Failed to remove participant ${callSid} from conference ${conferenceSid}:`, error);
+    console.error(`Failed to remove participant ${callSid} from conference ${conferenceSid}:`, error.message, { status: error.status, code: error.code });
     res.status(500).send({ error: 'Failed to remove conference participant' });
   }
 });

--- a/src/components/twilio-voice-dialer/routes.js
+++ b/src/components/twilio-voice-dialer/routes.js
@@ -30,12 +30,16 @@ router.post('/twiml', Twilio.webhook({ protocol: 'https' }, authToken), async (r
 
 // Validate incoming Twilio requests
 // https://www.twilio.com/docs/usage/tutorials/how-to-secure-your-express-app-by-validating-incoming-twilio-requests
-router.post('/conference-events', Twilio.webhook({ protocol: 'https' }, authToken), (req, res) =>
-  conferenceEventsHandler(
-    req,
-    res,
-    componentUrl
-  )
-);
+router.post('/conference-events', Twilio.webhook({ protocol: 'https' }, authToken), async (req, res) => {
+  try {
+    await conferenceEventsHandler(req, res, componentUrl);
+  } catch (error) {
+    console.error('Failed to handle conference-events:', error.message, {
+      status: error.status,
+      code: error.code,
+    });
+    if (!res.headersSent) res.sendStatus(200);
+  }
+});
 
 export default router;

--- a/src/components/twilio-voice-dialer/routes.js
+++ b/src/components/twilio-voice-dialer/routes.js
@@ -16,13 +16,17 @@ router.get('/token', (req, res) => tokenHandler(req, res));
 
 // Validate incoming Twilio requests
 // https://www.twilio.com/docs/usage/tutorials/how-to-secure-your-express-app-by-validating-incoming-twilio-requests
-router.post('/twiml', Twilio.webhook({ protocol: 'https' }, authToken), (req, res) =>
-  twimlHandler(
-    req,
-    res,
-    componentUrl
-  )
-);
+router.post('/twiml', Twilio.webhook({ protocol: 'https' }, authToken), async (req, res) => {
+  try {
+    await twimlHandler(req, res, componentUrl);
+  } catch (error) {
+    console.error('Failed to handle twiml:', error.message, {
+      status: error.status,
+      code: error.code,
+    });
+    if (!res.headersSent) res.sendStatus(500);
+  }
+});
 
 // Validate incoming Twilio requests
 // https://www.twilio.com/docs/usage/tutorials/how-to-secure-your-express-app-by-validating-incoming-twilio-requests

--- a/src/components/twilio-voice-monitoring/routes.js
+++ b/src/components/twilio-voice-monitoring/routes.js
@@ -63,11 +63,11 @@ router.post('/conference-events', Twilio.webhook({ protocol: 'https' }, authToke
     console.error('Failed to map callee to caller in conference-events:', error);
   }
 
-  conferenceEventsHandler(
+  return conferenceEventsHandler(
     req,
     res,
     componentUrl
-  )
+  );
 });
 
 // Validate incoming Twilio requests
@@ -98,8 +98,9 @@ router.post('/call-events', Twilio.webhook({ protocol: 'https' }, authToken), as
             }),
           });
       }
-      // Once the callee call is finished, drop the mapping to avoid leaking entries.
-      if (CallStatus === 'completed') {
+      // Once the callee call reaches any terminal status, drop the mapping to
+      // avoid leaking entries for calls that never reach 'completed'.
+      if (['completed', 'failed', 'busy', 'no-answer', 'canceled'].includes(CallStatus)) {
         calleeToCaller.delete(CallSid);
       }
     }

--- a/src/components/twilio-voice-monitoring/routes.js
+++ b/src/components/twilio-voice-monitoring/routes.js
@@ -81,7 +81,7 @@ router.post('/conference-events', Twilio.webhook({ protocol: 'https' }, authToke
         );
     }
   } catch (error) {
-    console.error('Failed to map callee to caller in conference-events:', error);
+    console.error('Failed to map callee to caller in conference-events:', error.message, { status: error.status, code: error.code });
   }
 
   try {

--- a/src/components/twilio-voice-monitoring/routes.js
+++ b/src/components/twilio-voice-monitoring/routes.js
@@ -16,10 +16,10 @@ const {
 } = config;
 const client = Twilio(apiKeySid, apiKeySecret, { accountSid });
 const componentUrl = 'twilio-voice-monitoring';
-let callerCallSidResolve;
-let callerCallSidPromise = new Promise((resolve) => {
-  callerCallSidResolve = resolve;
-});
+// Maps each callee's callSid to the caller (agent) callSid so the /call-events
+// webhook can route callee status updates to the correct caller leg. Keyed per
+// call rather than a single shared value so concurrent calls don't clobber it.
+const calleeToCaller = new Map();
 
 // Add your own authentication mechanism here to make sure this endpoint is only accessible to authorized users.
 router.get('/token', (req, res) => tokenHandler(req, res));
@@ -35,28 +35,33 @@ router.post('/twiml', Twilio.webhook({ protocol: 'https' }, authToken), (req, re
       callerLabel: 'agent',
       calleeLabel: 'customer',
       calleeStatusCallbackEvent: ['initiated', 'ringing', 'answered', 'completed'],
-      statusCallbackEvent: 'start, end, join, leave, mute, hold, modify, speaker, announcement',
+      statusCallbackEvent: 'start end join leave mute hold modify speaker announcement',
     }
   )
 );
 
 // Validate incoming Twilio requests
 // https://www.twilio.com/docs/usage/tutorials/how-to-secure-your-express-app-by-validating-incoming-twilio-requests
-router.post('/conference-events', Twilio.webhook({ protocol: 'https' }, authToken), (req, res) => {
-  const getCallerCallSid = async () => {
-    const {
-      ConferenceSid,
-    } = req.body;
+router.post('/conference-events', Twilio.webhook({ protocol: 'https' }, authToken), async (req, res) => {
+  // Build the callee -> caller mapping so /call-events can route callee status
+  // updates to the caller leg. The caller is labeled 'client-agent' (see twimlHandler).
+  try {
+    const { ConferenceSid } = req.body;
     const participants = await client
       .conferences(ConferenceSid)
       .participants
       .list();
-    // The caller is the first participant to enter the conference
-    if (participants.length === 1) {
-      callerCallSidResolve(participants[0].callSid);
-    };
-  };
-  getCallerCallSid();
+    const caller = participants.find(
+      (participant) => participant.label?.endsWith('-agent')
+    );
+    if (caller) {
+      participants
+        .filter((participant) => participant.callSid !== caller.callSid)
+        .forEach((callee) => calleeToCaller.set(callee.callSid, caller.callSid));
+    }
+  } catch (error) {
+    console.error('Failed to map callee to caller in conference-events:', error);
+  }
 
   conferenceEventsHandler(
     req,
@@ -73,22 +78,35 @@ router.post('/call-events', Twilio.webhook({ protocol: 'https' }, authToken), as
     CallSid,
     CallStatus,
   } = req.body;
-  const callerCallSid = await callerCallSidPromise;
-  const caller = await client.calls(callerCallSid).fetch();
-  if (caller?.status !== 'completed') {
-    // Send callee progress/status to caller
-    await client
-      .calls(callerCallSid)
-      .userDefinedMessages
-      .create({
-        content: JSON.stringify({
-          callSid: CallSid,
-          category: 'callee-call-status',
-          label: Called,
-          statusCallbackEvent: CallStatus,
-        }),
-      });
+  try {
+    const callerCallSid = calleeToCaller.get(CallSid);
+    // The caller may not be mapped yet for very early callee events (e.g. the
+    // first 'initiated'/'ringing' before /conference-events has run).
+    if (callerCallSid) {
+      const caller = await client.calls(callerCallSid).fetch();
+      if (caller?.status !== 'completed') {
+        // Send callee progress/status to caller
+        await client
+          .calls(callerCallSid)
+          .userDefinedMessages
+          .create({
+            content: JSON.stringify({
+              callSid: CallSid,
+              category: 'callee-call-status',
+              label: Called,
+              statusCallbackEvent: CallStatus,
+            }),
+          });
+      }
+      // Once the callee call is finished, drop the mapping to avoid leaking entries.
+      if (CallStatus === 'completed') {
+        calleeToCaller.delete(CallSid);
+      }
+    }
+  } catch (error) {
+    console.error(`Failed to relay callee status for ${CallSid}:`, error);
   }
+  res.sendStatus(200);
 });
 
 export default router;

--- a/src/components/twilio-voice-monitoring/routes.js
+++ b/src/components/twilio-voice-monitoring/routes.js
@@ -16,29 +16,43 @@ const {
 } = config;
 const client = Twilio(apiKeySid, apiKeySecret, { accountSid });
 const componentUrl = 'twilio-voice-monitoring';
-// Maps each callee's callSid to the caller (agent) callSid so the /call-events
-// webhook can route callee status updates to the correct caller leg. Keyed per
-// call rather than a single shared value so concurrent calls don't clobber it.
+// Maps each callee's callSid to the caller (agent) callSid so /call-events can
+// route callee status updates to the right caller leg. Entries carry a TTL so
+// they can't leak if a terminal status never arrives.
+// NOTE: process-local — in a multi-worker deployment the two webhooks can hit
+// different workers and relays will drop. For production use Redis/Twilio Sync.
+const CALLEE_MAPPING_TTL_MS = 2 * 60 * 60 * 1000; // 2 hours
 const calleeToCaller = new Map();
+
+// Drop expired entries. Called on insert so the Map stays bounded without a timer.
+function pruneCalleeMappings() {
+  const now = Date.now();
+  for (const [calleeCallSid, entry] of calleeToCaller) {
+    if (entry.expiresAt <= now) calleeToCaller.delete(calleeCallSid);
+  }
+}
 
 // Add your own authentication mechanism here to make sure this endpoint is only accessible to authorized users.
 router.get('/token', (req, res) => tokenHandler(req, res));
 
 // Validate incoming Twilio requests
 // https://www.twilio.com/docs/usage/tutorials/how-to-secure-your-express-app-by-validating-incoming-twilio-requests
-router.post('/twiml', Twilio.webhook({ protocol: 'https' }, authToken), (req, res) =>
-  twimlHandler(
-    req,
-    res,
-    componentUrl,
-    {
+router.post('/twiml', Twilio.webhook({ protocol: 'https' }, authToken), async (req, res) => {
+  try {
+    await twimlHandler(req, res, componentUrl, {
       callerLabel: 'agent',
       calleeLabel: 'customer',
       calleeStatusCallbackEvent: ['initiated', 'ringing', 'answered', 'completed'],
       statusCallbackEvent: 'start end join leave mute hold modify speaker announcement',
-    }
-  )
-);
+    });
+  } catch (error) {
+    console.error('Failed to handle twiml:', error.message, {
+      status: error.status,
+      code: error.code,
+    });
+    if (!res.headersSent) res.sendStatus(500);
+  }
+});
 
 // Validate incoming Twilio requests
 // https://www.twilio.com/docs/usage/tutorials/how-to-secure-your-express-app-by-validating-incoming-twilio-requests
@@ -55,19 +69,30 @@ router.post('/conference-events', Twilio.webhook({ protocol: 'https' }, authToke
       (participant) => participant.label?.endsWith('-agent')
     );
     if (caller) {
+      pruneCalleeMappings();
+      const expiresAt = Date.now() + CALLEE_MAPPING_TTL_MS;
       participants
         .filter((participant) => participant.callSid !== caller.callSid)
-        .forEach((callee) => calleeToCaller.set(callee.callSid, caller.callSid));
+        .forEach((callee) =>
+          calleeToCaller.set(callee.callSid, {
+            callerCallSid: caller.callSid,
+            expiresAt,
+          })
+        );
     }
   } catch (error) {
     console.error('Failed to map callee to caller in conference-events:', error);
   }
 
-  return conferenceEventsHandler(
-    req,
-    res,
-    componentUrl
-  );
+  try {
+    await conferenceEventsHandler(req, res, componentUrl);
+  } catch (error) {
+    console.error('Failed to handle conference-events:', error.message, {
+      status: error.status,
+      code: error.code,
+    });
+    if (!res.headersSent) res.sendStatus(200);
+  }
 });
 
 // Validate incoming Twilio requests
@@ -79,10 +104,12 @@ router.post('/call-events', Twilio.webhook({ protocol: 'https' }, authToken), as
     CallStatus,
   } = req.body;
   try {
-    const callerCallSid = calleeToCaller.get(CallSid);
-    // The caller may not be mapped yet for very early callee events (e.g. the
-    // first 'initiated'/'ringing' before /conference-events has run).
-    if (callerCallSid) {
+    const mapping = calleeToCaller.get(CallSid);
+    // Early 'initiated'/'ringing' events are dropped: the callee isn't a
+    // conference participant until it answers, so it isn't mapped yet. Showing
+    // dialing progress would need buffering/replay, omitted for this reference.
+    if (mapping) {
+      const callerCallSid = mapping.callerCallSid;
       const caller = await client.calls(callerCallSid).fetch();
       if (caller?.status !== 'completed') {
         // Send callee progress/status to caller
@@ -105,7 +132,12 @@ router.post('/call-events', Twilio.webhook({ protocol: 'https' }, authToken), as
       }
     }
   } catch (error) {
-    console.error(`Failed to relay callee status for ${CallSid}:`, error);
+    // Log only the error summary. The full Twilio error (and the callee CallSid)
+    // can pull phone numbers from the call resource into log aggregators.
+    console.error('Failed to relay callee status:', error.message, {
+      status: error.status,
+      code: error.code,
+    });
   }
   res.sendStatus(200);
 });


### PR DESCRIPTION
<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

1. 880a417 — Restored conference hold/mute controls by sending TwiML before adding the callee (so the conference is created with a working statusCallback) and fixing the statusCallbackEvent format from comma- to space-separated.
2. Replaced the unhandled-rejection `forEach(async)` pattern with awaited `Promise.allSettled`, swapped the monitoring component's single shared promise for a per-call `calleeToCaller` Map, and wrapped the participant CRUD handlers in try/catch; also bumped dotenv/express/ws onto patched releases.
3. 949bff4 ("clean up") — Applied 3 code-review follow-ups: generic 500 error bodies instead of leaking raw Twilio `error.message`, returning `conferenceEventsHandler` instead of fire-and-forget, and extending Map cleanup to all terminal call statuses.
4. Net effect: conference hold/mute works again, webhook handlers no longer crash or leak, and direct dependencies are on patched releases.
5. Updated packages

### Dependency bumps — advisories

- **express 4.21.0 → 4.22.2** pulls **cookie 0.6.0 → 0.7.2**, which fixes [CVE-2024-47764](https://github.com/advisories/GHSA-pxg6-pf52-xh8x) (cookie name/path/domain attribute injection, CWE-74).
- **dotenv 17.2.0 → 17.4.2** and **ws 8.18.3 → 8.21.0** are routine patch bumps; no specific advisory in the upgraded-from range (the ws ReDoS/DoS fixes predate 8.18.3).
- **path-to-regexp** was already on the patched 0.1.10 ([CVE-2024-45296](https://github.com/advisories/GHSA-9wv6-86v2-598j)) on `main`; it moves to 0.1.13 incidentally.
- **@twilio/voice-sdk 2.15.0 → 2.18.3** — no advisory; picks up bug fixes including a Chrome 146+ Permissions Policy violation fix (2.18.1) and a duplicate-PeerConnection fix (2.18.2). Releases are additive (remote audio processor, ESM GA); nothing breaking for these components.

> Note: `npm audit` is **not** fully clean — 1 high remains in `form-data` (CRLF injection via unescaped multipart field names) pulled transitively through the Twilio SDK. It cannot be resolved from this repo and requires an upstream SDK release.

Verified manual testing

